### PR TITLE
Fix compile error in example

### DIFF
--- a/an-example-we-can-build-upon.md
+++ b/an-example-we-can-build-upon.md
@@ -169,7 +169,6 @@ The last one is our `options`. These are unique for Rust and there are three opt
 ```rust
 fn main() {
     let mut ctx = ThreadContext::default();
-    let mut n = ThreadContext::default();
 
     let mut stack = vec![0_u8; SSIZE as usize];
     let stack_ptr = stack.as_mut_ptr();
@@ -177,7 +176,7 @@ fn main() {
     unsafe {
         std::ptr::write(stack_ptr.offset(SSIZE - 16) as *mut u64, hello as u64);
         ctx.rsp = stack_ptr.offset(SSIZE - 16) as u64;
-        gt_switch(&mut ctx, &mut n);
+        gt_switch(&mut ctx);
     }
 }
 ```


### PR DESCRIPTION
In the first example the `gt_switch` function is called with two thread contexts however it doesn't support switching between different contexts, only switching to a new one. The `n` thread context is unused when not being erroneously used to call `gt_switch` so I removed it too.

Note: GitHub decided to normalize all the line ending to `CR`, `LF`  when I edited hence all the whitespace changes. 

Great tutorial by the way 🙌