### PR TITLE
Some minor grammar fixes.

### DIFF
--- a/simple-but-unsafe-green-thread-implementation.md
+++ b/simple-but-unsafe-green-thread-implementation.md
@@ -216,7 +216,7 @@ If no thread is `Ready` we're all done. This is an extremely simple scheduler us
 {% hint style="info" %}
 This is a very naive implementation tailor-made for our example. What happens if our thread is not ready to make progress \(not in a `Ready` state\) and still waiting for a response from i.e. a database?
 
-it's not too difficult to work around this, instead of running our code directly when a thread is `Ready` we could instead poll it for a status. For example it could return `IsReady` if it's really ready to run or `Pending` if it's waiting for some operation to finish. In the latter case we could just leave it in it's `Ready` state to get polled again later. Does this sound familiar? If you've read about how [Futures](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures/task/enum.Poll.html#variant.Pending) work in Rust, we are starting to connect some dots on how this all fits together.
+it's not too difficult to work around this, instead of running our code directly when a thread is `Ready` we could instead poll it for a status. For example it could return `IsReady` if it's really ready to run or `Pending` if it's waiting for some operation to finish. In the latter case we could just leave it in its `Ready` state to get polled again later. Does this sound familiar? If you've read about how [Futures](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures/task/enum.Poll.html#variant.Pending) work in Rust, we are starting to connect some dots on how this all fits together.
 {% endhint %}
 
 If we find a thread that's ready to be run we change the state of the current thread from `Running` to `Ready`.

--- a/simple-but-unsafe-green-thread-implementation.md
+++ b/simple-but-unsafe-green-thread-implementation.md
@@ -65,7 +65,7 @@ struct ThreadContext {
 }
 ```
 
-`Runtime` is going to be where our main entry point. We are basically going to create a very small, simple runtime to schedule and switch between our threads. The runtime holds an array of `Threads` and a `current` field to indicate which thread we are currently running.
+`Runtime` is going to be our main entry point. We are basically going to create a very small, simple runtime to schedule and switch between our threads. The runtime holds an array of `Threads` and a `current` field to indicate which thread we are currently running.
 
 `Thread` holds data for a thread. Each thread has an `id` so we can separate them from each other. The `stack` is similar to what we saw in our first example in earlier chapters. The `ctx` field is a context representing the data our CPU needs to resume where it left of on a stack, and a `state` which is our thread state.
 

--- a/simple-but-unsafe-green-thread-implementation.md
+++ b/simple-but-unsafe-green-thread-implementation.md
@@ -67,7 +67,7 @@ struct ThreadContext {
 
 `Runtime` is going to be our main entry point. We are basically going to create a very small, simple runtime to schedule and switch between our threads. The runtime holds an array of `Threads` and a `current` field to indicate which thread we are currently running.
 
-`Thread` holds data for a thread. Each thread has an `id` so we can separate them from each other. The `stack` is similar to what we saw in our first example in earlier chapters. The `ctx` field is a context representing the data our CPU needs to resume where it left of on a stack, and a `state` which is our thread state.
+`Thread` holds data for a thread. Each thread has an `id` so we can separate them from each other. The `stack` is similar to what we saw in our first example in earlier chapters. The `ctx` field is a context representing the data our CPU needs to resume where it left off on a stack, and a `state` which is our thread state.
 
 `State` is an `enum` representing the states our threads can be in:
 

--- a/simple-but-unsafe-green-thread-implementation.md
+++ b/simple-but-unsafe-green-thread-implementation.md
@@ -214,7 +214,7 @@ Here we go through all the threads and see if anyone is in the `Ready` state whi
 If no thread is `Ready` we're all done. This is an extremely simple scheduler using only a round-robin algorithm, a real scheduler might have a much more sophisticated way of deciding what task to run next.
 
 {% hint style="info" %}
-This is a very naive implementation tailor made for our example. What happens if our thread is not ready to make progress \(not in a `Ready` state\) and still waiting for a response from i.e. a database?
+This is a very naive implementation tailor-made for our example. What happens if our thread is not ready to make progress \(not in a `Ready` state\) and still waiting for a response from i.e. a database?
 
 it's not too difficult to work around this, instead of running our code directly when a thread is `Ready` we could instead poll it for a status. For example it could return `IsReady` if it's really ready to run or `Pending` if it's waiting for some operation to finish. In the latter case we could just leave it in it's `Ready` state to get polled again later. Does this sound familiar? If you've read about how [Futures](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures/task/enum.Poll.html#variant.Pending) work in Rust, we are starting to connect some dots on how this all fits together.
 {% endhint %}


### PR DESCRIPTION
I first noticed the sentence "`Runtime` is going to be where our main entry point." and attempted a fix.  I'm not 100% certain, as another potential fix is adding "is" to the end of the sentence, but that seems less likely to be what you're saying here.

While I was at it I did a few other minor fixes to issues I noticed in the same file.