### PR TITLE
Add const representing the size of the stack frame for System V ABI

### DIFF
--- a/the-stack.md
+++ b/the-stack.md
@@ -148,6 +148,7 @@ If you see anything you don't recognize in this code, relax, we will go through 
 use std::io::Write;
 
 const SSIZE: isize = 1024;
+const SYSTEM_V_ABI_STACK_FRAME_SIZE: isize = 16;
 static mut S_PTR: *const u8 = 0 as *const u8;
 
 #[derive(Debug, Default)]
@@ -203,9 +204,12 @@ fn main() {
 
     unsafe {
         S_PTR = stack_ptr;
-        std::ptr::write(stack_ptr.offset(SSIZE - 16) as *mut u64, hello as u64);
+        std::ptr::write(
+            stack_ptr.offset(SSIZE - SYSTEM_V_ABI_STACK_FRAME_SIZE) as *mut u64,
+            hello as u64,
+        );
         print_stack("BEFORE.txt");
-        ctx.rsp = stack_ptr.offset(SSIZE - 16) as u64;
+        ctx.rsp = stack_ptr.offset(SSIZE - SYSTEM_V_ABI_STACK_FRAME_SIZE) as u64;
         gt_switch(&mut ctx);
     }
 }


### PR DESCRIPTION
Thank you for taking your time to provide this resource @cfsamson, it has been a super insightful read so far. :)

The reason I'm proposing this change is that it is not so easy to find this information unless we know exactly what we are looking for, this can potentially clarify the code and help readers understand where these numbers are coming from by just glancing at the `const` name. What do you think? 