### PR TITLE
Make code runnable in latest rust for "An example we can build upon" section

### DIFF
--- a/an-example-we-can-build-upon.md
+++ b/an-example-we-can-build-upon.md
@@ -158,9 +158,9 @@ The last one is our `options`. These are unique for Rust and there are three opt
 fn main() {
     let mut ctx = ThreadContext::default();
     let mut stack = vec![0_u8; SSIZE as usize];
-    let stack_bottom = stack.as_mut_ptr().offset(SSIZE);
 
     unsafe {
+        let stack_bottom = stack.as_mut_ptr().offset(SSIZE);
         let sb_aligned = (stack_bottom as usize & !15) as *mut u8;
         std::ptr::write(sb_aligned.offset(-16) as *mut u64, hello as u64);
         ctx.rsp = sb_aligned.offset(-16) as u64;


### PR DESCRIPTION
moves stack_bottom initialization into unsafe block as offset method is now unsafe

I assume that this is suppose to be a runnable example, and so the initialization
of `stack_bottom` needs to be moved into the `unsafe` block

Docs for `pointer.offset` method
https://doc.rust-lang.org/std/primitive.pointer.html#method.offset